### PR TITLE
Split VoLTE and VoWiFi checks and UI elements. Fixes #3.

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+EnableVoLTE

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -19,30 +19,49 @@
             android:layout_marginStart="8dp"
             android:layout_marginEnd="8dp"
             android:layout_marginBottom="8dp"
-            android:orientation="horizontal"
+            android:orientation="vertical"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent">
 
-            <Button
-                android:id="@+id/enable_ims_btn"
-                android:layout_width="wrap_content"
+            <LinearLayout
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:insetRight="8dp"
-                android:enabled="@{data.shizukuGranted &amp;&amp; data.subscriptionId >= 0 &amp;&amp; data.deviceIMSEnabled &amp;&amp; !data.carrierIMSEnabled}"
-                android:onClick="@{() -> protocol.onEnableVoLTEClick()}"
-                android:text="Enable VoLTE" />
+                android:layout_marginStart="8dp"
+                android:layout_marginEnd="8dp"
+                android:orientation="horizontal" >
+
+                <Button
+                    android:id="@+id/enable_volte_btn"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:insetRight="8dp"
+                    android:enabled="@{data.shizukuGranted &amp;&amp; data.subscriptionId >= 0 &amp;&amp; data.deviceVolteEnabled &amp;&amp; !data.carrierVolteEnabled}"
+                    android:onClick="@{() -> protocol.onEnableVoLTEClick()}"
+                    android:text="Enable VoLTE" />
+
+                <Button
+                    android:id="@+id/enable_vowifi_btn"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:enabled="@{data.shizukuGranted &amp;&amp; data.subscriptionId >= 0 &amp;&amp; data.deviceVolteEnabled &amp;&amp; !data.carrierVowifiEnabled}"
+                    android:onClick="@{() -> protocol.onEnableVoWiFiClick()}"
+                    android:text="Enable VoWiFi" />
+
+            </LinearLayout>
 
             <Button
                 android:id="@+id/disable_ims_btn"
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
                 android:insetLeft="8dp"
-                android:enabled="@{data.shizukuGranted &amp;&amp; data.subscriptionId >= 0 &amp;&amp; data.deviceIMSEnabled &amp;&amp; data.carrierIMSEnabled}"
+                android:insetRight="8dp"
+                android:enabled="@{data.shizukuGranted &amp;&amp; data.subscriptionId >= 0 &amp;&amp; data.deviceVolteEnabled &amp;&amp; data.carrierVolteEnabled}"
                 android:onClick="@{() -> protocol.onClearSettingClick()}"
-                android:text="Clear Setting" />
+                android:text="Clear Settings" />
         </LinearLayout>
 
         <LinearLayout
@@ -90,7 +109,7 @@
                 android:id="@+id/volte_supported_by_device_switch"
                 android:layout_width="match_parent"
                 android:layout_height="48dp"
-                android:checked="@{data.deviceIMSEnabled}"
+                android:checked="@{data.deviceVolteEnabled}"
                 android:clickable="false"
                 android:enabled="@{data.shizukuGranted}"
                 android:text="VoLTE Supported by Device"
@@ -105,17 +124,17 @@
             android:layout_marginEnd="8dp"
             android:layout_marginBottom="16dp"
             android:orientation="vertical"
-            app:layout_constraintBottom_toTopOf="@+id/linearLayout"
+            app:layout_constraintBottom_toTopOf="@+id/textView7"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent">
 
             <Switch
-                android:id="@+id/ims_config_enabled_switch"
+                android:id="@+id/volte_config_enabled_switch"
                 android:layout_width="match_parent"
                 android:layout_height="48dp"
-                android:checked="@{data.carrierIMSEnabled}"
+                android:checked="@{data.carrierVolteEnabled}"
                 android:clickable="false"
-                android:enabled="@{data.deviceIMSEnabled &amp;&amp; data.subscriptionId >= 0}"
+                android:enabled="@{data.deviceVolteEnabled &amp;&amp; data.subscriptionId >= 0}"
                 android:text="VoLTE Enabled by Config"
                 android:textColor="?android:attr/textColorPrimaryNoDisable" />
 
@@ -125,9 +144,33 @@
                 android:layout_height="48dp"
                 android:checked="@{data.isIMSRunning}"
                 android:clickable="false"
-                android:enabled="@{data.deviceIMSEnabled &amp;&amp; data.subscriptionId >= 0}"
+                android:enabled="@{data.deviceVolteEnabled &amp;&amp; data.subscriptionId >= 0}"
                 android:text="System Utilizing VoLTE"
                 android:textColor="?android:attr/textColorPrimaryNoDisable" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/linearLayout4"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_marginEnd="8dp"
+            android:layout_marginBottom="16dp"
+            android:orientation="vertical"
+            app:layout_constraintBottom_toTopOf="@+id/linearLayout"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent">
+
+            <Switch
+                android:id="@+id/vowifi_config_enabled_switch"
+                android:layout_width="match_parent"
+                android:layout_height="48dp"
+                android:checked="@{data.carrierVowifiEnabled}"
+                android:clickable="false"
+                android:enabled="@{data.carrierVowifiEnabled &amp;&amp; data.subscriptionId >= 0}"
+                android:text="VoWiFi Enabled by Config"
+                android:textColor="?android:attr/textColorPrimaryNoDisable" />
+
         </LinearLayout>
 
         <TextView
@@ -150,6 +193,17 @@
             android:text="VoLTE Status"
             android:textSize="18sp"
             app:layout_constraintBottom_toTopOf="@+id/linearLayout2"
+            app:layout_constraintStart_toStartOf="parent" />
+
+        <TextView
+            android:id="@+id/textView7"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_marginBottom="4dp"
+            android:text="VoWiFi Status"
+            android:textSize="18sp"
+            app:layout_constraintBottom_toTopOf="@+id/linearLayout4"
             app:layout_constraintStart_toStartOf="parent" />
 
         <TextView


### PR DESCRIPTION
PR that addresses issue #3. I renamed VoLTE-specific things (IMS -> VoLTE) so we can easily tell them apart from VoWiFi ones.

---

Please note:

I have removed the `KEY_CARRIER_AVAILABLE_VT_BOOL` setting for now, as it's not related to VoWiFi in any way. That's actually the setting for [ViLTE](https://www.gsma.com/futurenetworks/ip_services/vilte/), the Video over LTE feature that was standardised years ago by carriers (VT = [Video Telephony](https://developer.android.com/reference/android/telephony/CarrierConfigManager#KEY_CARRIER_VT_AVAILABLE_BOOL)).

Happy to add a third button for that if you want, although I'm not sure if carriers are actually using it nowadays.