### PR TITLE
Add VoNR toggle support

### DIFF
--- a/app/src/main/java/dev/bluehouse/enablevolte/Moder.kt
+++ b/app/src/main/java/dev/bluehouse/enablevolte/Moder.kt
@@ -165,6 +165,9 @@ class SubscriptionModer(val subscriptionId: Int) : Moder() {
 
     val isVolteConfigEnabled: Boolean
         get() = this.getBooleanValue(CarrierConfigManager.KEY_CARRIER_VOLTE_AVAILABLE_BOOL)
+        
+    val isVonrConfigEnabled: Boolean
+        get() = this.getBooleanValue(CarrierConfigManager.KEY_VONR_ENABLED_BOOL)
 
     val isVowifiConfigEnabled: Boolean
         get() = this.getBooleanValue(CarrierConfigManager.KEY_CARRIER_WFC_IMS_AVAILABLE_BOOL)

--- a/app/src/main/java/dev/bluehouse/enablevolte/pages/Config.kt
+++ b/app/src/main/java/dev/bluehouse/enablevolte/pages/Config.kt
@@ -81,6 +81,16 @@ fun Config(navController: NavController, subId: Int) {
                 true
             }
         }
+        BooleanPropertyView(label = "Enable VoNR", toggled = voNREnabled) {
+            voNREnabled = if (voNREnabled) {
+                moder.updateCarrierConfig(CarrierConfigManager.KEY_VONR_ENABLED_BOOL, false)
+                false
+            } else {
+                moder.updateCarrierConfig(CarrierConfigManager.KEY_VONR_ENABLED_BOOL, true)
+                moder.restartIMSRegistration()
+                true
+            }
+        }
         BooleanPropertyView(label = "Enable VoWiFi", toggled = voWiFiEnabled) {
             voWiFiEnabled = if (voWiFiEnabled) {
                 moder.updateCarrierConfig(CarrierConfigManager.KEY_CARRIER_WFC_IMS_AVAILABLE_BOOL, false)

--- a/app/src/main/java/dev/bluehouse/enablevolte/pages/Config.kt
+++ b/app/src/main/java/dev/bluehouse/enablevolte/pages/Config.kt
@@ -33,6 +33,7 @@ fun Config(navController: NavController, subId: Int) {
 
     var configurable by rememberSaveable { mutableStateOf(false) }
     var voLTEEnabled by rememberSaveable { mutableStateOf(false) }
+    var voNREnabled by rememberSaveable { mutableStateOf(false) }
     var voWiFiEnabled by rememberSaveable { mutableStateOf(false) }
     var vtEnabled by rememberSaveable { mutableStateOf(false) }
     var show4GForLteEnabled by rememberSaveable { mutableStateOf(false) }
@@ -42,6 +43,7 @@ fun Config(navController: NavController, subId: Int) {
 
     fun loadFlags() {
         voLTEEnabled = moder.isVolteConfigEnabled
+        voNREnabled = moder.isVonrConfigEnabled
         voWiFiEnabled = moder.isVowifiConfigEnabled
         vtEnabled = moder.isVtConfigEnabled
         show4GForLteEnabled = moder.isShow4GForLteEnabled


### PR DESCRIPTION
This adds VoNR toggle support. Devices supporting SA may or may not have VoNR toggle setting visible. The default bool value for the toggle is false per AOSP. Requires modem support to truly work, but that is independent of Android.