### PR TITLE
feat: add more toggles for Wi-Fi Calling

### DIFF
--- a/app/src/main/java/dev/bluehouse/enablevolte/Moder.kt
+++ b/app/src/main/java/dev/bluehouse/enablevolte/Moder.kt
@@ -111,6 +111,14 @@ class SubscriptionModer(val subscriptionId: Int) : Moder() {
         iCclInstance.overrideConfig(this.subscriptionId, overrideBundle, true)
     }
 
+    fun updateCarrierConfig(key: String, value: Int) {
+        Log.d(TAG, "Setting $key to $value")
+        val iCclInstance = this.loadCachedInterface { carrierConfigLoader }
+        val overrideBundle = PersistableBundle()
+        overrideBundle.putInt(key, value)
+        iCclInstance.overrideConfig(this.subscriptionId, overrideBundle, true)
+    }
+
     fun updateCarrierConfig(key: String, value: IntArray) {
         Log.d(TAG, "Setting $key to $value")
         val iCclInstance = this.loadCachedInterface { carrierConfigLoader }
@@ -152,6 +160,17 @@ class SubscriptionModer(val subscriptionId: Int) : Moder() {
         return config.getBoolean(key)
     }
 
+    private fun getIntValue(key: String): Int {
+        val subscriptionId = this.subscriptionId
+        if (subscriptionId < 0) {
+            return -1
+        }
+        val iCclInstance = this.loadCachedInterface { carrierConfigLoader }
+
+        val config = iCclInstance.getConfigForSubId(subscriptionId, iCclInstance.defaultCarrierServicePackageName)
+        return config.getInt(key)
+    }
+
     private fun getIntArrayValue(key: String): IntArray {
         val subscriptionId = this.subscriptionId
         if (subscriptionId < 0) {
@@ -168,6 +187,18 @@ class SubscriptionModer(val subscriptionId: Int) : Moder() {
 
     val isVowifiConfigEnabled: Boolean
         get() = this.getBooleanValue(CarrierConfigManager.KEY_CARRIER_WFC_IMS_AVAILABLE_BOOL)
+
+    val showVoWifiMode: Boolean
+        get() = this.getBooleanValue(CarrierConfigManager.KEY_EDITABLE_WFC_MODE_BOOL)
+
+    val showVoWifiRoamingMode: Boolean
+        get() = this.getBooleanValue(CarrierConfigManager.KEY_EDITABLE_WFC_ROAMING_MODE_BOOL)
+
+    val showVoWifiInNetworkName: Int
+        get() = this.getIntValue(CarrierConfigManager.KEY_WFC_SPN_FORMAT_IDX_INT)
+
+    val supportWfcWifiOnly: Boolean
+        get() = this.getBooleanValue(CarrierConfigManager.KEY_CARRIER_WFC_SUPPORTS_WIFI_ONLY_BOOL)
 
     val isVtConfigEnabled: Boolean
         get() = this.getBooleanValue(CarrierConfigManager.KEY_CARRIER_VT_AVAILABLE_BOOL)

--- a/app/src/main/java/dev/bluehouse/enablevolte/pages/Config.kt
+++ b/app/src/main/java/dev/bluehouse/enablevolte/pages/Config.kt
@@ -101,7 +101,7 @@ fun Config(navController: NavController, subId: Int) {
                 true
             }
         }
-        BooleanPropertyView(label = "Show VoWiFi preference in Settings", toggled = showVoWifiMode) {
+        BooleanPropertyView(label = stringResource(R.string.show_vowifi_preference_in_settings), toggled = showVoWifiMode) {
             showVoWifiMode = if (showVoWifiMode) {
                 moder.updateCarrierConfig(CarrierConfigManager.KEY_EDITABLE_WFC_MODE_BOOL, false)
                 false
@@ -111,7 +111,7 @@ fun Config(navController: NavController, subId: Int) {
                 true
             }
         }
-        BooleanPropertyView(label = "Show VoWiFi Roaming preference in Settings", toggled = showVoWifiRoamingMode) {
+        BooleanPropertyView(label = stringResource(R.string.show_vowifi_roaming_preference_in_settings), toggled = showVoWifiRoamingMode) {
             showVoWifiRoamingMode = if (showVoWifiRoamingMode) {
                 moder.updateCarrierConfig(CarrierConfigManager.KEY_EDITABLE_WFC_ROAMING_MODE_BOOL, false)
                 false
@@ -121,7 +121,7 @@ fun Config(navController: NavController, subId: Int) {
                 true
             }
         }
-        BooleanPropertyView(label = "Add \"Wi-Fi Calling\" to Network Name", toggled = showVoWifiInNetworkName) {
+        BooleanPropertyView(label = stringResource(R.string.add_wifi_calling_to_network_name), toggled = showVoWifiInNetworkName) {
             showVoWifiInNetworkName = if (showVoWifiInNetworkName) {
                 moder.updateCarrierConfig(CarrierConfigManager.KEY_WFC_SPN_FORMAT_IDX_INT, 0)
                 false
@@ -131,7 +131,7 @@ fun Config(navController: NavController, subId: Int) {
                 true
             }
         }
-        BooleanPropertyView(label = "Allow VoWiFi in Aeroplane Mode", toggled = supportWfcWifiOnly) {
+        BooleanPropertyView(label = stringResource(R.string.allow_vowifi_in_aeroplane_mode), toggled = supportWfcWifiOnly) {
             supportWfcWifiOnly = if (supportWfcWifiOnly) {
                 moder.updateCarrierConfig(CarrierConfigManager.KEY_CARRIER_WFC_SUPPORTS_WIFI_ONLY_BOOL, false)
                 false

--- a/app/src/main/java/dev/bluehouse/enablevolte/pages/Config.kt
+++ b/app/src/main/java/dev/bluehouse/enablevolte/pages/Config.kt
@@ -36,6 +36,10 @@ fun Config(navController: NavController, subId: Int) {
     var configurable by rememberSaveable { mutableStateOf(false) }
     var voLTEEnabled by rememberSaveable { mutableStateOf(false) }
     var voWiFiEnabled by rememberSaveable { mutableStateOf(false) }
+    var showVoWifiMode by rememberSaveable { mutableStateOf(false) }
+    var showVoWifiRoamingMode by rememberSaveable { mutableStateOf(false) }
+    var showVoWifiInNetworkName by rememberSaveable { mutableStateOf(false) }
+    var supportWfcWifiOnly by rememberSaveable { mutableStateOf(false) }
     var vtEnabled by rememberSaveable { mutableStateOf(false) }
     var show4GForLteEnabled by rememberSaveable { mutableStateOf(false) }
     var hideEnhancedDataIconEnabled by rememberSaveable { mutableStateOf(false) }
@@ -45,6 +49,10 @@ fun Config(navController: NavController, subId: Int) {
     fun loadFlags() {
         voLTEEnabled = moder.isVolteConfigEnabled
         voWiFiEnabled = moder.isVowifiConfigEnabled
+        showVoWifiMode = moder.showVoWifiMode
+        showVoWifiRoamingMode = moder.showVoWifiRoamingMode
+        showVoWifiInNetworkName = (moder.showVoWifiInNetworkName == 1)
+        supportWfcWifiOnly = moder.supportWfcWifiOnly
         vtEnabled = moder.isVtConfigEnabled
         show4GForLteEnabled = moder.isShow4GForLteEnabled
         hideEnhancedDataIconEnabled = moder.isHideEnhancedDataIconEnabled
@@ -89,6 +97,46 @@ fun Config(navController: NavController, subId: Int) {
                 false
             } else {
                 moder.updateCarrierConfig(CarrierConfigManager.KEY_CARRIER_WFC_IMS_AVAILABLE_BOOL, true)
+                moder.restartIMSRegistration()
+                true
+            }
+        }
+        BooleanPropertyView(label = "Show VoWiFi preference in Settings", toggled = showVoWifiMode) {
+            showVoWifiMode = if (showVoWifiMode) {
+                moder.updateCarrierConfig(CarrierConfigManager.KEY_EDITABLE_WFC_MODE_BOOL, false)
+                false
+            } else {
+                moder.updateCarrierConfig(CarrierConfigManager.KEY_EDITABLE_WFC_MODE_BOOL, true)
+                moder.restartIMSRegistration()
+                true
+            }
+        }
+        BooleanPropertyView(label = "Show VoWiFi Roaming preference in Settings", toggled = showVoWifiRoamingMode) {
+            showVoWifiRoamingMode = if (showVoWifiRoamingMode) {
+                moder.updateCarrierConfig(CarrierConfigManager.KEY_EDITABLE_WFC_ROAMING_MODE_BOOL, false)
+                false
+            } else {
+                moder.updateCarrierConfig(CarrierConfigManager.KEY_EDITABLE_WFC_ROAMING_MODE_BOOL, true)
+                moder.restartIMSRegistration()
+                true
+            }
+        }
+        BooleanPropertyView(label = "Add \"Wi-Fi Calling\" to Network Name", toggled = showVoWifiInNetworkName) {
+            showVoWifiInNetworkName = if (showVoWifiInNetworkName) {
+                moder.updateCarrierConfig(CarrierConfigManager.KEY_WFC_SPN_FORMAT_IDX_INT, 0)
+                false
+            } else {
+                moder.updateCarrierConfig(CarrierConfigManager.KEY_WFC_SPN_FORMAT_IDX_INT, 1)
+                moder.restartIMSRegistration()
+                true
+            }
+        }
+        BooleanPropertyView(label = "Allow VoWiFi in Aeroplane Mode", toggled = supportWfcWifiOnly) {
+            supportWfcWifiOnly = if (supportWfcWifiOnly) {
+                moder.updateCarrierConfig(CarrierConfigManager.KEY_CARRIER_WFC_SUPPORTS_WIFI_ONLY_BOOL, false)
+                false
+            } else {
+                moder.updateCarrierConfig(CarrierConfigManager.KEY_CARRIER_WFC_SUPPORTS_WIFI_ONLY_BOOL, true)
                 moder.restartIMSRegistration()
                 true
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,6 +12,10 @@
     <string name="shizuku_permission_granted">Shizuku Permission Granted</string>
     <string name="enable_volte">Enable VoLTE</string>
     <string name="enable_vowifi">Enable VoWiFi</string>
+    <string name="show_vowifi_preference_in_settings">Show VoWiFi preference in Settings</string>
+    <string name="show_vowifi_roaming_preference_in_settings">Show VoWiFi Roaming preference in Settings</string>
+    <string name="add_wifi_calling_to_network_name">Add "Wi-Fi Calling" to Network Name</string>
+    <string name="allow_vowifi_in_aeroplane_mode">Allow VoWiFi in Aeroplane Mode</string>
     <string name="enable_video_calling_vt">Enable Video Calling (VT)</string>
     <string name="sim_detected">SIM Detected</string>
     <string name="volte_supported_by_device">VoLTE Supported by Device</string>


### PR DESCRIPTION
This PR adds some VoViFi-related toggles:
1. Show/hide Wi-Fi Calling preference in Settings
2. Show/hide Wi-Fi Calling roaming preference in Settings
3. Add/hide "Wi-Fi Calling" in network name when VoWiFi is available
4. Enable/disable VoWiFi in Aeroplane Mode. Should solve https://github.com/kyujin-cho/pixel-volte-patch/issues/15 This also adds a "WiFi only" preference for calls, useful when roaming.