### PR TITLE
fix: VoWiFi while roaming

### DIFF
--- a/app/src/main/java/dev/bluehouse/enablevolte/pages/Config.kt
+++ b/app/src/main/java/dev/bluehouse/enablevolte/pages/Config.kt
@@ -98,9 +98,13 @@ fun Config(navController: NavController, subId: Int) {
         BooleanPropertyView(label = stringResource(R.string.enable_vowifi), toggled = voWiFiEnabled) {
             voWiFiEnabled = if (voWiFiEnabled) {
                 moder.updateCarrierConfig(CarrierConfigManager.KEY_CARRIER_WFC_IMS_AVAILABLE_BOOL, false)
+                moder.updateCarrierConfig(CarrierConfigManager.KEY_CARRIER_DEFAULT_WFC_IMS_ENABLED_BOOL, false)
+                moder.updateCarrierConfig(CarrierConfigManager.KEY_CARRIER_DEFAULT_WFC_IMS_ROAMING_ENABLED_BOOL, false)
                 false
             } else {
                 moder.updateCarrierConfig(CarrierConfigManager.KEY_CARRIER_WFC_IMS_AVAILABLE_BOOL, true)
+                moder.updateCarrierConfig(CarrierConfigManager.KEY_CARRIER_DEFAULT_WFC_IMS_ENABLED_BOOL, true)
+                moder.updateCarrierConfig(CarrierConfigManager.KEY_CARRIER_DEFAULT_WFC_IMS_ROAMING_ENABLED_BOOL, true)
                 moder.restartIMSRegistration()
                 true
             }


### PR DESCRIPTION
By default, using VoWiFi while roaming is disabled and there is no switch in Android Settings to enable it. Adding KEY_CARRIER_DEFAULT_WFC_IMS_ROAMING_ENABLED_BOOL allows to use VoWiFi while roaming, if operator permits it.

This patch also enables KEY_CARRIER_DEFAULT_WFC_IMS_ENABLED_BOOL to set VoWiFi on when it is enabled in this app.

Details in https://github.com/kyujin-cho/pixel-volte-patch/discussions/63
The patch was tested with Orange PL SIM card while roaming.