### PR TITLE
Remove VoWiFi roaming preference toggle

### DIFF
--- a/app/src/main/java/dev/bluehouse/enablevolte/Moder.kt
+++ b/app/src/main/java/dev/bluehouse/enablevolte/Moder.kt
@@ -191,9 +191,6 @@ class SubscriptionModer(val subscriptionId: Int) : Moder() {
     val showVoWifiMode: Boolean
         get() = this.getBooleanValue(CarrierConfigManager.KEY_EDITABLE_WFC_MODE_BOOL)
 
-    val showVoWifiRoamingMode: Boolean
-        get() = this.getBooleanValue(CarrierConfigManager.KEY_EDITABLE_WFC_ROAMING_MODE_BOOL)
-
     val showVoWifiInNetworkName: Int
         get() = this.getIntValue(CarrierConfigManager.KEY_WFC_SPN_FORMAT_IDX_INT)
 

--- a/app/src/main/java/dev/bluehouse/enablevolte/pages/Config.kt
+++ b/app/src/main/java/dev/bluehouse/enablevolte/pages/Config.kt
@@ -37,7 +37,6 @@ fun Config(navController: NavController, subId: Int) {
     var voLTEEnabled by rememberSaveable { mutableStateOf(false) }
     var voWiFiEnabled by rememberSaveable { mutableStateOf(false) }
     var showVoWifiMode by rememberSaveable { mutableStateOf(false) }
-    var showVoWifiRoamingMode by rememberSaveable { mutableStateOf(false) }
     var showVoWifiInNetworkName by rememberSaveable { mutableStateOf(false) }
     var supportWfcWifiOnly by rememberSaveable { mutableStateOf(false) }
     var vtEnabled by rememberSaveable { mutableStateOf(false) }
@@ -50,7 +49,6 @@ fun Config(navController: NavController, subId: Int) {
         voLTEEnabled = moder.isVolteConfigEnabled
         voWiFiEnabled = moder.isVowifiConfigEnabled
         showVoWifiMode = moder.showVoWifiMode
-        showVoWifiRoamingMode = moder.showVoWifiRoamingMode
         showVoWifiInNetworkName = (moder.showVoWifiInNetworkName == 1)
         supportWfcWifiOnly = moder.supportWfcWifiOnly
         vtEnabled = moder.isVtConfigEnabled
@@ -111,16 +109,6 @@ fun Config(navController: NavController, subId: Int) {
                 false
             } else {
                 moder.updateCarrierConfig(CarrierConfigManager.KEY_EDITABLE_WFC_MODE_BOOL, true)
-                moder.restartIMSRegistration()
-                true
-            }
-        }
-        BooleanPropertyView(label = stringResource(R.string.show_vowifi_roaming_preference_in_settings), toggled = showVoWifiRoamingMode) {
-            showVoWifiRoamingMode = if (showVoWifiRoamingMode) {
-                moder.updateCarrierConfig(CarrierConfigManager.KEY_EDITABLE_WFC_ROAMING_MODE_BOOL, false)
-                false
-            } else {
-                moder.updateCarrierConfig(CarrierConfigManager.KEY_EDITABLE_WFC_ROAMING_MODE_BOOL, true)
                 moder.restartIMSRegistration()
                 true
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,7 +14,6 @@
     <string name="enable_volte">Enable VoLTE</string>
     <string name="enable_vowifi">Enable VoWiFi</string>
     <string name="show_vowifi_preference_in_settings">Show VoWiFi preference in Settings</string>
-    <string name="show_vowifi_roaming_preference_in_settings">Show VoWiFi Roaming preference in Settings</string>
     <string name="add_wifi_calling_to_network_name">Add "Wi-Fi Calling" to Network Name</string>
     <string name="allow_vowifi_in_aeroplane_mode">Allow VoWiFi in Aeroplane Mode</string>
     <string name="enable_video_calling_vt">Enable Video Calling (VT)</string>


### PR DESCRIPTION
From testing, this preference is not respected even with KEY_USE_WFC_HOME_NETWORK_MODE_IN_ROAMING_NETWORK_BOOL set to false.