### PR TITLE
Rename WiFi only mode for VoWiFi

### DIFF
--- a/app/src/main/java/dev/bluehouse/enablevolte/pages/Config.kt
+++ b/app/src/main/java/dev/bluehouse/enablevolte/pages/Config.kt
@@ -135,7 +135,7 @@ fun Config(navController: NavController, subId: Int) {
                 true
             }
         }
-        BooleanPropertyView(label = stringResource(R.string.allow_vowifi_in_aeroplane_mode), toggled = supportWfcWifiOnly) {
+        BooleanPropertyView(label = stringResource(R.string.show_wifi_only_for_vowifi), toggled = supportWfcWifiOnly) {
             supportWfcWifiOnly = if (supportWfcWifiOnly) {
                 moder.updateCarrierConfig(CarrierConfigManager.KEY_CARRIER_WFC_SUPPORTS_WIFI_ONLY_BOOL, false)
                 false

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,7 +16,7 @@
     <string name="show_vowifi_preference_in_settings">Show VoWiFi preference in Settings</string>
     <string name="show_vowifi_roaming_preference_in_settings">Show VoWiFi Roaming preference in Settings</string>
     <string name="add_wifi_calling_to_network_name">Add "Wi-Fi Calling" to Network Name</string>
-    <string name="allow_vowifi_in_aeroplane_mode">Allow VoWiFi in Aeroplane Mode</string>
+    <string name="show_wifi_only_for_vowifi">Show "WiFi only" mode for VoWiFi</string>
     <string name="enable_video_calling_vt">Enable Video Calling (VT)</string>
     <string name="sim_detected">SIM Detected</string>
     <string name="volte_supported_by_device">VoLTE Supported by Device</string>


### PR DESCRIPTION
KEY_CARRIER_WFC_SUPPORTS_WIFI_ONLY_BOOL does not explicitly enable VoWiFi in Aeroplane mode, as it may be allowed even without this key. Instead, it adds "WiFi only" mode for calling, useful when roaming to avoid costs. Rename the toggle for clarity.