### PR TITLE
fix: do not set KEY_CARRIER_DEFAULT_WFC_IMS_ENABLED_BOOL

### DIFF
--- a/app/src/main/java/dev/bluehouse/enablevolte/pages/Config.kt
+++ b/app/src/main/java/dev/bluehouse/enablevolte/pages/Config.kt
@@ -108,11 +108,9 @@ fun Config(navController: NavController, subId: Int) {
         BooleanPropertyView(label = stringResource(R.string.enable_vowifi), toggled = voWiFiEnabled) {
             voWiFiEnabled = if (voWiFiEnabled) {
                 moder.updateCarrierConfig(CarrierConfigManager.KEY_CARRIER_WFC_IMS_AVAILABLE_BOOL, false)
-                moder.updateCarrierConfig(CarrierConfigManager.KEY_CARRIER_DEFAULT_WFC_IMS_ENABLED_BOOL, false)
                 false
             } else {
                 moder.updateCarrierConfig(CarrierConfigManager.KEY_CARRIER_WFC_IMS_AVAILABLE_BOOL, true)
-                moder.updateCarrierConfig(CarrierConfigManager.KEY_CARRIER_DEFAULT_WFC_IMS_ENABLED_BOOL, true)
                 moder.restartIMSRegistration()
                 true
             }


### PR DESCRIPTION
In AOSP, the only carrier using it is T-Mobile US. Other carriers seem to not require it.

Reverts toggle behavior to 1.2.2