### PR TITLE
fix: app crash and eSIM index issue

### DIFF
--- a/app/src/main/java/dev/bluehouse/enablevolte/Utils.kt
+++ b/app/src/main/java/dev/bluehouse/enablevolte/Utils.kt
@@ -19,7 +19,7 @@ fun checkShizukuPermission(code: Int): Boolean {
 }
 
 val SubscriptionInfo.uniqueName: String
-    get() = "${this.cardId} - ${this.displayName}"
+    get() = "${this.subscriptionId} - ${this.displayName}"
 
 fun getLatestAppVersion(handler: (String) -> Unit) {
     "https://api.github.com/repos/kyujin-cho/pixel-volte-patch/releases"

--- a/app/src/main/java/dev/bluehouse/enablevolte/pages/Home.kt
+++ b/app/src/main/java/dev/bluehouse/enablevolte/pages/Home.kt
@@ -108,10 +108,14 @@ fun Home(navController: NavController) {
         BooleanPropertyView(label = stringResource(R.string.volte_supported_by_device), toggled = deviceIMSEnabled)
 
         for (idx in subscriptions.indices) {
+            var isRegistered = false
+            if (isIMSRegistered.isNotEmpty()) {
+                isRegistered = isIMSRegistered[idx]
+            }
             HeaderText(text = stringResource(R.string.ims_status_for, "${subscriptions[idx].uniqueName}"))
             BooleanPropertyView(
                 label = stringResource(R.string.ims_status),
-                toggled = isIMSRegistered[idx],
+                toggled = isRegistered,
                 trueLabel = stringResource(R.string.registered),
                 falseLabel = stringResource(R.string.unregistered),
             )


### PR DESCRIPTION
fix #139  in cf6b740
use cardId will make two esim all be zero
see https://developer.android.com/guide/topics/connectivity/telecom/telephony-ids

fix a app crash issuse in d0c2a03

when device not support ims, `isIMSRegistered` will be a empty list,and `isIMSRegistered[idx]` will get `IndexOutOfBoundsException`
(although nothing been change in display because this BooleanPropertyView did not have an onclick event)