### PR TITLE
feat: add pixel 5a to docs

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -24,7 +24,8 @@ Carriers which aren't possible for testing by developer but reported as supporte
 
 ### Requirement
 
-- Pixel device with Google Tensor Chipset
+- Pixel device with Android 11 or higher
+  - Google Pixel 5a
   - Google Pixel 6
   - Google Pixel 6a
   - Google Pixel 6 Pro

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ English version available [here](https://github.com/kyujin-cho/pixel-volte-patch
 
 ### 준비물
 
-- Google Tensor Chipset이 적용되었으며 Android 11 이상이 설치된 Pixel 단말기
+- 적용되었으며 Android 11 이상이 설치된 Pixel 단말기
+  - Google Pixel 5a
   - Google Pixel 6
   - Google Pixel 6a
   - Google Pixel 6 Pro


### PR DESCRIPTION
Successfully let Pixel 5A to enable and use VoLTE and VoWiFi. Tested with UK Lebara (Vodafone network).