### PR TITLE
chore(deps): lower minimum SDK version to 29

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,7 +9,7 @@ android {
 
     defaultConfig {
         applicationId "dev.bluehouse.enablevolte"
-        minSdk 30
+        minSdk 29
         targetSdk 33
         versionCode 12
         versionName "1.2.7"


### PR DESCRIPTION
This still doesn't mean that I will regard android devices other than Pixel as supported devices. AYOR!