### PR TITLE
fix: support app start and value read until SDK 34 since SDK 28 despite no value update guarantee

### DIFF
--- a/app/src/main/java/dev/bluehouse/enablevolte/Moder.kt
+++ b/app/src/main/java/dev/bluehouse/enablevolte/Moder.kt
@@ -128,7 +128,8 @@ class CarrierModer(
             val sub = this.loadCachedInterface { sub }
             try {
                 return sub.getActiveSubscriptionInfoList(null, null, true) ?: emptyList()
-            } catch (e: NoSuchMethodError) {}
+            } catch (e: NoSuchMethodError) {
+            }
             return try {
                 val getActiveSubscriptionInfoListMethod =
                     sub.javaClass.getMethod(
@@ -398,10 +399,14 @@ class SubscriptionModer(
         return config.get(key)
     }
 
-    fun getConfigForSubId(iCclInstance: ICarrierConfigLoader, subscriptionId: Int): PersistableBundle {
+    fun getConfigForSubId(
+        iCclInstance: ICarrierConfigLoader,
+        subscriptionId: Int,
+    ): PersistableBundle {
         try {
             return iCclInstance.getConfigForSubIdWithFeature(subscriptionId, iCclInstance.defaultCarrierServicePackageName, "")
-        } catch (e: NoSuchMethodError) {}
+        } catch (e: NoSuchMethodError) {
+        }
         return try {
             iCclInstance.getConfigForSubId(subscriptionId, iCclInstance.defaultCarrierServicePackageName)
         } catch (e: NoSuchMethodError) {

--- a/app/src/main/java/dev/bluehouse/enablevolte/Moder.kt
+++ b/app/src/main/java/dev/bluehouse/enablevolte/Moder.kt
@@ -99,7 +99,7 @@ class CarrierModer(
         get() {
             val sub = this.loadCachedInterface { sub }
             try {
-                return sub.getActiveSubscriptionInfoList(null, null, true)
+                return sub.getActiveSubscriptionInfoList(null, null, true) ?: emptyList()
             } catch (e: NoSuchMethodError) {}
             return try {
                 val getActiveSubscriptionInfoListMethod =
@@ -108,14 +108,14 @@ class CarrierModer(
                         String::class.java,
                         String::class.java,
                     )
-                (getActiveSubscriptionInfoListMethod.invoke(sub, null, null) as List<SubscriptionInfo>)
+                (getActiveSubscriptionInfoListMethod.invoke(sub, null, null) as? List<SubscriptionInfo>) ?: emptyList()
             } catch (e: NoSuchMethodException) {
                 val getActiveSubscriptionInfoListMethod =
                     sub.javaClass.getMethod(
                         "getActiveSubscriptionInfoList",
                         String::class.java,
                     )
-                (getActiveSubscriptionInfoListMethod.invoke(sub, null) as List<SubscriptionInfo>)
+                (getActiveSubscriptionInfoListMethod.invoke(sub, null) as? List<SubscriptionInfo>) ?: emptyList()
             }
         }
 

--- a/app/src/main/java/dev/bluehouse/enablevolte/Moder.kt
+++ b/app/src/main/java/dev/bluehouse/enablevolte/Moder.kt
@@ -98,18 +98,24 @@ class CarrierModer(
     val subscriptions: List<SubscriptionInfo>
         get() {
             val sub = this.loadCachedInterface { sub }
+            try {
+                return sub.getActiveSubscriptionInfoList(null, null, true)
+            } catch (e: NoSuchMethodError) {}
             return try {
-                sub.getActiveSubscriptionInfoList(null, null, true)
-            } catch (e: NoSuchMethodError) {
-                // FIXME: lift up reflect as soon as official source code releases
                 val getActiveSubscriptionInfoListMethod =
                     sub.javaClass.getMethod(
                         "getActiveSubscriptionInfoList",
                         String::class.java,
                         String::class.java,
-                        Boolean::class.java,
                     )
-                (getActiveSubscriptionInfoListMethod.invoke(sub, null, null, false) as List<SubscriptionInfo>)
+                (getActiveSubscriptionInfoListMethod.invoke(sub, null, null) as List<SubscriptionInfo>)
+            } catch (e: NoSuchMethodException) {
+                val getActiveSubscriptionInfoListMethod =
+                    sub.javaClass.getMethod(
+                        "getActiveSubscriptionInfoList",
+                        String::class.java,
+                    )
+                (getActiveSubscriptionInfoListMethod.invoke(sub, null) as List<SubscriptionInfo>)
             }
         }
 

--- a/app/src/main/java/dev/bluehouse/enablevolte/Moder.kt
+++ b/app/src/main/java/dev/bluehouse/enablevolte/Moder.kt
@@ -460,7 +460,7 @@ class SubscriptionModer(
     val wfcSpnFormatIndex: Int
         get() = this.getIntValue(CarrierConfigManager.KEY_WFC_SPN_FORMAT_IDX_INT)
 
-    val carrierName: String
+    val carrierName: String?
         get() = this.loadCachedInterface { telephony }.getSubscriptionCarrierName(this.subscriptionId)
 
     val showVoWifiIcon: Boolean

--- a/app/src/main/java/dev/bluehouse/enablevolte/Moder.kt
+++ b/app/src/main/java/dev/bluehouse/enablevolte/Moder.kt
@@ -9,6 +9,7 @@ import android.os.Build
 import android.os.Build.VERSION_CODES
 import android.os.Bundle
 import android.os.IInterface
+import android.os.PersistableBundle
 import android.os.ServiceManager
 import android.telephony.CarrierConfigManager
 import android.telephony.SubscriptionInfo
@@ -309,7 +310,7 @@ class SubscriptionModer(
         }
         val iCclInstance = this.loadCachedInterface { carrierConfigLoader }
 
-        val config = iCclInstance.getConfigForSubIdWithFeature(subscriptionId, iCclInstance.defaultCarrierServicePackageName, "")
+        val config = this.getConfigForSubId(iCclInstance, subscriptionId)
         return config.getString(key)
     }
 
@@ -321,7 +322,7 @@ class SubscriptionModer(
         }
         val iCclInstance = this.loadCachedInterface { carrierConfigLoader }
 
-        val config = iCclInstance.getConfigForSubIdWithFeature(subscriptionId, iCclInstance.defaultCarrierServicePackageName, "")
+        val config = this.getConfigForSubId(iCclInstance, subscriptionId)
         return config.getBoolean(key)
     }
 
@@ -333,7 +334,7 @@ class SubscriptionModer(
         }
         val iCclInstance = this.loadCachedInterface { carrierConfigLoader }
 
-        val config = iCclInstance.getConfigForSubIdWithFeature(subscriptionId, iCclInstance.defaultCarrierServicePackageName, "")
+        val config = this.getConfigForSubId(iCclInstance, subscriptionId)
         return config.getInt(key)
     }
 
@@ -345,7 +346,7 @@ class SubscriptionModer(
         }
         val iCclInstance = this.loadCachedInterface { carrierConfigLoader }
 
-        val config = iCclInstance.getConfigForSubIdWithFeature(subscriptionId, iCclInstance.defaultCarrierServicePackageName, "")
+        val config = this.getConfigForSubId(iCclInstance, subscriptionId)
         return config.getLong(key)
     }
 
@@ -357,7 +358,7 @@ class SubscriptionModer(
         }
         val iCclInstance = this.loadCachedInterface { carrierConfigLoader }
 
-        val config = iCclInstance.getConfigForSubIdWithFeature(subscriptionId, iCclInstance.defaultCarrierServicePackageName, "")
+        val config = this.getConfigForSubId(iCclInstance, subscriptionId)
         return config.getBooleanArray(key) ?: BooleanArray(0)
     }
 
@@ -369,7 +370,7 @@ class SubscriptionModer(
         }
         val iCclInstance = this.loadCachedInterface { carrierConfigLoader }
 
-        val config = iCclInstance.getConfigForSubIdWithFeature(subscriptionId, iCclInstance.defaultCarrierServicePackageName, "")
+        val config = this.getConfigForSubId(iCclInstance, subscriptionId)
         return config.getIntArray(key) ?: IntArray(0)
     }
 
@@ -381,7 +382,7 @@ class SubscriptionModer(
         }
         val iCclInstance = this.loadCachedInterface { carrierConfigLoader }
 
-        val config = iCclInstance.getConfigForSubIdWithFeature(subscriptionId, iCclInstance.defaultCarrierServicePackageName, "")
+        val config = this.getConfigForSubId(iCclInstance, subscriptionId)
         return config.getStringArray(key) ?: emptyArray()
     }
 
@@ -393,8 +394,24 @@ class SubscriptionModer(
         }
         val iCclInstance = this.loadCachedInterface { carrierConfigLoader }
 
-        val config = iCclInstance.getConfigForSubIdWithFeature(subscriptionId, iCclInstance.defaultCarrierServicePackageName, "")
+        val config = this.getConfigForSubId(iCclInstance, subscriptionId)
         return config.get(key)
+    }
+
+    fun getConfigForSubId(iCclInstance: ICarrierConfigLoader, subscriptionId: Int): PersistableBundle {
+        try {
+            return iCclInstance.getConfigForSubIdWithFeature(subscriptionId, iCclInstance.defaultCarrierServicePackageName, "")
+        } catch (e: NoSuchMethodError) {}
+        return try {
+            iCclInstance.getConfigForSubId(subscriptionId, iCclInstance.defaultCarrierServicePackageName)
+        } catch (e: NoSuchMethodError) {
+            val getConfigForSubIdMethod =
+                iCclInstance.javaClass.getMethod(
+                    "getConfigForSubId",
+                    Int::class.javaPrimitiveType,
+                )
+            (getConfigForSubIdMethod.invoke(iCclInstance, subscriptionId) as PersistableBundle)
+        }
     }
 
     val simSlotIndex: Int

--- a/app/src/main/java/dev/bluehouse/enablevolte/Moder.kt
+++ b/app/src/main/java/dev/bluehouse/enablevolte/Moder.kt
@@ -109,7 +109,17 @@ class CarrierModer(
 ) : Moder() {
     fun getActiveSubscriptionInfoForSimSlotIndex(index: Int): SubscriptionInfo? {
         val sub = this.loadCachedInterface { sub }
-        return sub.getActiveSubscriptionInfoForSimSlotIndex(index, null, null)
+        return try {
+            sub.getActiveSubscriptionInfoForSimSlotIndex(index, null, null)
+        } catch (e: NoSuchMethodError) {
+            val getActiveSubscriptionInfoForSimSlotIndexMethod =
+                sub.javaClass.getMethod(
+                    "getActiveSubscriptionInfoForSimSlotIndex",
+                    Int::class.javaPrimitiveType,
+                    String::class.java,
+                )
+            (getActiveSubscriptionInfoForSimSlotIndexMethod.invoke(sub, index, null) as? SubscriptionInfo)
+        }
     }
 
     val subscriptions: List<SubscriptionInfo>

--- a/app/src/main/java/dev/bluehouse/enablevolte/Moder.kt
+++ b/app/src/main/java/dev/bluehouse/enablevolte/Moder.kt
@@ -312,7 +312,7 @@ class SubscriptionModer(
         val iCclInstance = this.loadCachedInterface { carrierConfigLoader }
 
         val config = this.getConfigForSubId(iCclInstance, subscriptionId)
-        return config.getString(key)
+        return config?.getString(key)
     }
 
     fun getBooleanValue(key: String): Boolean {
@@ -324,7 +324,7 @@ class SubscriptionModer(
         val iCclInstance = this.loadCachedInterface { carrierConfigLoader }
 
         val config = this.getConfigForSubId(iCclInstance, subscriptionId)
-        return config.getBoolean(key)
+        return config?.getBoolean(key) ?: false
     }
 
     fun getIntValue(key: String): Int {
@@ -336,7 +336,7 @@ class SubscriptionModer(
         val iCclInstance = this.loadCachedInterface { carrierConfigLoader }
 
         val config = this.getConfigForSubId(iCclInstance, subscriptionId)
-        return config.getInt(key)
+        return config?.getInt(key) ?: -1
     }
 
     fun getLongValue(key: String): Long {
@@ -348,7 +348,7 @@ class SubscriptionModer(
         val iCclInstance = this.loadCachedInterface { carrierConfigLoader }
 
         val config = this.getConfigForSubId(iCclInstance, subscriptionId)
-        return config.getLong(key)
+        return config?.getLong(key) ?: -1L
     }
 
     fun getBooleanArrayValue(key: String): BooleanArray {
@@ -360,7 +360,7 @@ class SubscriptionModer(
         val iCclInstance = this.loadCachedInterface { carrierConfigLoader }
 
         val config = this.getConfigForSubId(iCclInstance, subscriptionId)
-        return config.getBooleanArray(key) ?: BooleanArray(0)
+        return config?.getBooleanArray(key) ?: BooleanArray(0)
     }
 
     fun getIntArrayValue(key: String): IntArray {
@@ -372,7 +372,7 @@ class SubscriptionModer(
         val iCclInstance = this.loadCachedInterface { carrierConfigLoader }
 
         val config = this.getConfigForSubId(iCclInstance, subscriptionId)
-        return config.getIntArray(key) ?: IntArray(0)
+        return config?.getIntArray(key) ?: IntArray(0)
     }
 
     fun getStringArrayValue(key: String): Array<String> {
@@ -384,7 +384,7 @@ class SubscriptionModer(
         val iCclInstance = this.loadCachedInterface { carrierConfigLoader }
 
         val config = this.getConfigForSubId(iCclInstance, subscriptionId)
-        return config.getStringArray(key) ?: emptyArray()
+        return config?.getStringArray(key) ?: emptyArray()
     }
 
     fun getValue(key: String): Any? {
@@ -396,13 +396,13 @@ class SubscriptionModer(
         val iCclInstance = this.loadCachedInterface { carrierConfigLoader }
 
         val config = this.getConfigForSubId(iCclInstance, subscriptionId)
-        return config.get(key)
+        return config?.get(key)
     }
 
     fun getConfigForSubId(
         iCclInstance: ICarrierConfigLoader,
         subscriptionId: Int,
-    ): PersistableBundle {
+    ): PersistableBundle? {
         try {
             return iCclInstance.getConfigForSubIdWithFeature(subscriptionId, iCclInstance.defaultCarrierServicePackageName, "")
         } catch (e: NoSuchMethodError) {
@@ -415,7 +415,7 @@ class SubscriptionModer(
                     "getConfigForSubId",
                     Int::class.javaPrimitiveType,
                 )
-            (getConfigForSubIdMethod.invoke(iCclInstance, subscriptionId) as PersistableBundle)
+            (getConfigForSubIdMethod.invoke(iCclInstance, subscriptionId) as? PersistableBundle)
         }
     }
 

--- a/app/src/main/java/dev/bluehouse/enablevolte/Moder.kt
+++ b/app/src/main/java/dev/bluehouse/enablevolte/Moder.kt
@@ -9,6 +9,7 @@ import android.os.Build
 import android.os.Build.VERSION_CODES
 import android.os.Bundle
 import android.os.IInterface
+import android.os.ServiceManager
 import android.telephony.CarrierConfigManager
 import android.telephony.SubscriptionInfo
 import android.telephony.TelephonyFrameworkInitializer
@@ -46,10 +47,14 @@ open class Moder {
         get() =
             ICarrierConfigLoader.Stub.asInterface(
                 ShizukuBinderWrapper(
-                    TelephonyFrameworkInitializer
-                        .getTelephonyServiceManager()
-                        .carrierConfigServiceRegisterer
-                        .get()!!,
+                    try {
+                        TelephonyFrameworkInitializer
+                            .getTelephonyServiceManager()
+                            .carrierConfigServiceRegisterer
+                            .get()
+                    } catch (e: NoClassDefFoundError) {
+                        ServiceManager.getService(Context.CARRIER_CONFIG_SERVICE)
+                    }!!,
                 ),
             )
 
@@ -57,10 +62,14 @@ open class Moder {
         get() =
             ITelephony.Stub.asInterface(
                 ShizukuBinderWrapper(
-                    TelephonyFrameworkInitializer
-                        .getTelephonyServiceManager()
-                        .telephonyServiceRegisterer
-                        .get()!!,
+                    try {
+                        TelephonyFrameworkInitializer
+                            .getTelephonyServiceManager()
+                            .telephonyServiceRegisterer
+                            .get()
+                    } catch (e: NoClassDefFoundError) {
+                        ServiceManager.getService(Context.TELEPHONY_SERVICE)
+                    }!!,
                 ),
             )
 
@@ -68,10 +77,14 @@ open class Moder {
         get() =
             IPhoneSubInfo.Stub.asInterface(
                 ShizukuBinderWrapper(
-                    TelephonyFrameworkInitializer
-                        .getTelephonyServiceManager()
-                        .phoneSubServiceRegisterer
-                        .get()!!,
+                    try {
+                        TelephonyFrameworkInitializer
+                            .getTelephonyServiceManager()
+                            .phoneSubServiceRegisterer
+                            .get()
+                    } catch (e: NoClassDefFoundError) {
+                        ServiceManager.getService("iphonesubinfo")
+                    }!!,
                 ),
             )
 
@@ -79,10 +92,14 @@ open class Moder {
         get() =
             ISub.Stub.asInterface(
                 ShizukuBinderWrapper(
-                    TelephonyFrameworkInitializer
-                        .getTelephonyServiceManager()
-                        .subscriptionServiceRegisterer
-                        .get()!!,
+                    try {
+                        TelephonyFrameworkInitializer
+                            .getTelephonyServiceManager()
+                            .subscriptionServiceRegisterer
+                            .get()
+                    } catch (e: NoClassDefFoundError) {
+                        ServiceManager.getService("isub")
+                    }!!,
                 ),
             )
 }


### PR DESCRIPTION
Fixes #401, closes #329, resolves #389, reactivating #231 which once fixed #225 by dealing with `NoSuchMethodError` thrown from `getActiveSubscriptionInfoList` but seems to have mistakenly been reverted since #387 which has started to throw the new `NoSuchMethodException` until [SDK 34](https://android.googlesource.com/platform/frameworks/base/+/android14-release/telephony/java/com/android/internal/telephony/ISub.aidl#85).
Supports another old `getActiveSubscriptionInfoList` function signature which had been used until [SDK 29](https://android.googlesource.com/platform/frameworks/base/+/android10-release/telephony/java/com/android/internal/telephony/ISub.aidl#83).

The `as?` and `emptyList` fix the following bug as `SubscriptionManager` has also prevented since [SDK 35](https://android.googlesource.com/platform/frameworks/base/+/android15-release/telephony/java/android/telephony/SubscriptionManager.java#1975), saying, "Beginning with Android SDK 35, this method will never return null":

```kotlin
2025-12-11 15:02:16.122 24303-24303 AndroidRuntime          dev.bluehouse.enablevolte            E  FATAL EXCEPTION: main
Process: dev.bluehouse.enablevolte, PID: 24303
java.lang.NullPointerException: null cannot be cast to non-null type kotlin.collections.List<android.telephony.SubscriptionInfo>
	at dev.bluehouse.enablevolte.CarrierModer.getSubscriptions(Moder.kt:118)
	at dev.bluehouse.enablevolte.HomeActivityKt.PixelIMSApp$loadApplication(HomeActivity.kt:138)
	at dev.bluehouse.enablevolte.HomeActivityKt.PixelIMSApp$lambda$10$0(HomeActivity.kt:161)
	at dev.bluehouse.enablevolte.HomeActivityKt.$r8$lambda$zhbMr68U3UlSP60qr7a6FsMZemQ(Unknown Source:0)
	at dev.bluehouse.enablevolte.HomeActivityKt$$ExternalSyntheticLambda21.invoke(D8$$SyntheticClass:0)
	at dev.bluehouse.enablevolte.components.CommonKt.OnLifecycleEvent$lambda$0$0$0(Common.kt:27)
	at dev.bluehouse.enablevolte.components.CommonKt.$r8$lambda$vXeNtcL85q_1p4Nf-9xaXgM7pCw(Unknown Source:0)
	at dev.bluehouse.enablevolte.components.CommonKt$$ExternalSyntheticLambda4.onStateChanged(D8$$SyntheticClass:0)
	at androidx.lifecycle.LifecycleRegistry$ObserverWithState.dispatchEvent(LifecycleRegistry.jvm.kt:313)
	at androidx.lifecycle.LifecycleRegistry.forwardPass(LifecycleRegistry.jvm.kt:251)
	at androidx.lifecycle.LifecycleRegistry.sync(LifecycleRegistry.jvm.kt:288)
	at androidx.lifecycle.LifecycleRegistry.addObserver(LifecycleRegistry.jvm.kt:198)
	at androidx.compose.ui.platform.WrappedComposition$setContent$1.invoke(Wrapper.android.kt:121)
	at androidx.compose.ui.platform.WrappedComposition$setContent$1.invoke(Wrapper.android.kt:114)
	at androidx.compose.ui.platform.AndroidComposeView.onAttachedToWindow(AndroidComposeView.android.kt:2077)
	at android.view.View.dispatchAttachedToWindow(View.java:18365)
	at android.view.ViewGroup.dispatchAttachedToWindow(ViewGroup.java:3477)
	at android.view.ViewGroup.dispatchAttachedToWindow(ViewGroup.java:3484)
	at android.view.ViewGroup.dispatchAttachedToWindow(ViewGroup.java:3484)
	at android.view.ViewGroup.dispatchAttachedToWindow(ViewGroup.java:3484)
	at android.view.ViewGroup.dispatchAttachedToWindow(ViewGroup.java:3484)
	at android.view.ViewRootImpl.performTraversals(ViewRootImpl.java:1776)
	at android.view.ViewRootImpl.doTraversal(ViewRootImpl.java:1475)
	at android.view.ViewRootImpl$TraversalRunnable.run(ViewRootImpl.java:7218)
	at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1012)
	at android.view.Choreographer.doCallbacks(Choreographer.java:823)
	at android.view.Choreographer.doFrame(Choreographer.java:758)
	at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:998)
	at android.os.Handler.handleCallback(Handler.java:873)
	at android.os.Handler.dispatchMessage(Handler.java:99)
	at android.os.Looper.loop(Looper.java:193)
	at android.app.ActivityThread.main(ActivityThread.java:6826)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:858)
```

Fixes https://github.com/kyujin-cho/pixel-volte-patch/issues/420#issuecomment-3586240375, closes https://github.com/kyujin-cho/pixel-volte-patch/issues/398#issuecomment-3408980514, resolves https://github.com/kyujin-cho/pixel-volte-patch/issues/423#issuecomment-3626872536, only about `NullPointerException` thrown from `getSubscriptionCarrierName` which might return null in some cases according to its [specification](https://android.googlesource.com/platform/frameworks/base/+/android16-release/telephony/java/com/android/internal/telephony/ITelephony.aidl#1584).

Fixes #273, closes https://github.com/kyujin-cho/pixel-volte-patch/issues/320#issuecomment-2612872573, resolving `NoClassDefFoundError` thrown from `TelephonyFrameworkInitializer` added since SDK 30.
We can bypass its `TelephonyServiceManager` whose methods are just [refactored](https://android.googlesource.com/platform/frameworks/base/+/d9eebca1c2e5d32473887efe2e39ab47d892fbc1) results.

Supports old `getActiveSubscriptionInfoForSimSlotIndex` whose function signature had been different from that of today until [SDK 29](https://android.googlesource.com/platform/frameworks/base/+/android10-release/telephony/java/com/android/internal/telephony/ISub.aidl#60), catching `NoSuchMethodError`.

Supports deprecated `getConfigForSubId` on `NoSuchMethodError` in place of `getConfigForSubIdWithFeature` which had not been added until [SDK 29](https://android.googlesource.com/platform/frameworks/base/+/android10-release/telephony/java/com/android/internal/telephony/ICarrierConfigLoader.aidl#27)

Fixes the following `NullPointerException` thrown from `getConfigForSubIdWithFeature` unlike its non-null [implementation](https://android.googlesource.com/platform/packages/services/Telephony/+/android16-release/src/com/android/phone/CarrierConfigLoader.java#1368), by considering it nullable:

```kotlin
12-27 23:36:35.578  3936  3936 E AndroidRuntime: FATAL EXCEPTION: main
12-27 23:36:35.578  3936  3936 E AndroidRuntime: Process: dev.bluehouse.enablevolte, PID: 3936
12-27 23:36:35.578  3936  3936 E AndroidRuntime: java.lang.NullPointerException: getConfigForSubIdWithFeature(...) must not be null
12-27 23:36:35.578  3936  3936 E AndroidRuntime: 	at dev.bluehouse.enablevolte.SubscriptionModer.getConfigForSubId(Moder.kt:437)
12-27 23:36:35.578  3936  3936 E AndroidRuntime: 	at dev.bluehouse.enablevolte.SubscriptionModer.getBooleanValue(Moder.kt:356)
12-27 23:36:35.578  3936  3936 E AndroidRuntime: 	at dev.bluehouse.enablevolte.SubscriptionModer.isVoLteConfigEnabled(Moder.kt:456)
12-27 23:36:35.578  3936  3936 E AndroidRuntime: 	at dev.bluehouse.enablevolte.pages.ConfigKt.Config$loadFlags(Config.kt:95)
12-27 23:36:35.578  3936  3936 E AndroidRuntime: 	at dev.bluehouse.enablevolte.pages.ConfigKt.access$Config$loadFlags(Config.kt:1)
12-27 23:36:35.578  3936  3936 E AndroidRuntime: 	at dev.bluehouse.enablevolte.pages.ConfigKt$Config$1$1$1.invokeSuspend(Config.kt:123)
12-27 23:36:35.578  3936  3936 E AndroidRuntime: 	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:34)
12-27 23:36:35.578  3936  3936 E AndroidRuntime: 	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100)
12-27 23:36:35.578  3936  3936 E AndroidRuntime: 	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:586)
12-27 23:36:35.578  3936  3936 E AndroidRuntime: 	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:829)
12-27 23:36:35.578  3936  3936 E AndroidRuntime: 	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:717)
12-27 23:36:35.578  3936  3936 E AndroidRuntime: 	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:704)
12-27 23:36:35.578  3936  3936 E AndroidRuntime: 	Suppressed: kotlinx.coroutines.internal.DiagnosticCoroutineContextException: [androidx.compose.ui.platform.MotionDurationScaleImpl@3e4e2a0, androidx.compose.runtime.BroadcastFrameClock@d416e59, StandaloneCoroutine{Cancelling}@6514a1e, AndroidUiDispatcher@665e2ff]
```

Supports another function signature of `getConfigForSubId` declared until [SDK 28](https://android.googlesource.com/platform/frameworks/base/+/pie-release/telephony/java/com/android/internal/telephony/ICarrierConfigLoader.aidl#26).

You can download and test the built apk here but need to uninstall the previous release if any: https://github.com/yhkee0404/pixel-volte-patch/releases/tag/1.3.1_PR_426_430_431_432

안녕하세요 ㅎㅎ 처음 뵙겠습니다!