### PR TITLE
fix: support value update since SDK 29 despite persistent=false

### DIFF
--- a/app/src/main/java/dev/bluehouse/enablevolte/BrokerInstrumentation.kt
+++ b/app/src/main/java/dev/bluehouse/enablevolte/BrokerInstrumentation.kt
@@ -28,12 +28,14 @@ class BrokerInstrumentation : Instrumentation() {
             try {
                 return configurationManager.overrideConfig(subId, overrideValues, true)
             } catch (e: SecurityException) {
-            } catch (e: NoSuchMethodError) {}
+            } catch (e: NoSuchMethodError) {
+            }
 
             try {
                 return configurationManager.overrideConfig(subId, overrideValues, false)
             } catch (e: SecurityException) {
-            } catch (e: NoSuchMethodError) {}
+            } catch (e: NoSuchMethodError) {
+            }
 
             configurationManager.overrideConfig(subId, overrideValues)
         } finally {

--- a/app/src/main/java/dev/bluehouse/enablevolte/BrokerInstrumentation.kt
+++ b/app/src/main/java/dev/bluehouse/enablevolte/BrokerInstrumentation.kt
@@ -26,14 +26,7 @@ class BrokerInstrumentation : Instrumentation() {
             val configurationManager = this.context.getSystemService(CarrierConfigManager::class.java)
 
             try {
-                return configurationManager.overrideConfig(subId, overrideValues, true)
-            } catch (e: SecurityException) {
-            } catch (e: NoSuchMethodError) {
-            }
-
-            try {
-                return configurationManager.overrideConfig(subId, overrideValues, false)
-            } catch (e: SecurityException) {
+                return configurationManager.overrideConfig(subId, overrideValues, overrideConfigPersistent)
             } catch (e: NoSuchMethodError) {
             }
 

--- a/app/src/main/java/dev/bluehouse/enablevolte/BrokerInstrumentation.kt
+++ b/app/src/main/java/dev/bluehouse/enablevolte/BrokerInstrumentation.kt
@@ -5,6 +5,7 @@ import android.app.IActivityManager
 import android.app.Instrumentation
 import android.content.Context
 import android.os.Bundle
+import android.os.PersistableBundle
 import android.system.Os
 import android.telephony.CarrierConfigManager
 import android.util.Log
@@ -15,52 +16,49 @@ const val TAG = "BrokerInstrumentation"
 
 class BrokerInstrumentation : Instrumentation() {
     @SuppressLint("MissingPermission")
+    private fun overrideConfig(
+        subId: Int,
+        overrideValues: PersistableBundle?,
+    ) {
+        val am = IActivityManager.Stub.asInterface(ShizukuBinderWrapper(SystemServiceHelper.getSystemService(Context.ACTIVITY_SERVICE)))
+        try {
+            am.startDelegateShellPermissionIdentity(Os.getuid(), null)
+            val configurationManager = this.context.getSystemService(CarrierConfigManager::class.java)
+
+            try {
+                return configurationManager.overrideConfig(subId, overrideValues, true)
+            } catch (e: SecurityException) {
+            } catch (e: NoSuchMethodError) {}
+
+            try {
+                return configurationManager.overrideConfig(subId, overrideValues, false)
+            } catch (e: SecurityException) {
+            } catch (e: NoSuchMethodError) {}
+
+            configurationManager.overrideConfig(subId, overrideValues)
+        } finally {
+            am.stopDelegateShellPermissionIdentity()
+        }
+    }
+
     private fun applyConfig(
         subId: Int,
         arguments: Bundle,
     ) {
         Log.i(TAG, "applyConfig")
-        val am = IActivityManager.Stub.asInterface(ShizukuBinderWrapper(SystemServiceHelper.getSystemService(Context.ACTIVITY_SERVICE)))
-        am.startDelegateShellPermissionIdentity(Os.getuid(), null)
         try {
-            val configurationManager = this.context.getSystemService(CarrierConfigManager::class.java)
-            val overrideValues = toPersistableBundle(arguments)
-
-            try {
-                configurationManager.overrideConfig(subId, overrideValues, true)
-            } catch (e: SecurityException) {
-                if (e.message?.contains("overrideConfig with persistent=true only can be invoked by system app") == true) {
-                    configurationManager.overrideConfig(subId, overrideValues, false)
-                } else {
-                    throw e
-                }
-            }
+            this.overrideConfig(subId, toPersistableBundle(arguments))
         } finally {
             Log.i(TAG, "applyConfig done")
-            am.stopDelegateShellPermissionIdentity()
         }
     }
 
-    @SuppressLint("MissingPermission")
     private fun clearConfig(subId: Int) {
         Log.i(TAG, "clearConfig")
-        val am = IActivityManager.Stub.asInterface(ShizukuBinderWrapper(SystemServiceHelper.getSystemService(Context.ACTIVITY_SERVICE)))
-        am.startDelegateShellPermissionIdentity(Os.getuid(), null)
         try {
-            val configurationManager = this.context.getSystemService(CarrierConfigManager::class.java)
-
-            try {
-                configurationManager.overrideConfig(subId, null, true)
-            } catch (e: SecurityException) {
-                if (e.message?.contains("overrideConfig with persistent=true only can be invoked by system app") == true) {
-                    configurationManager.overrideConfig(subId, null, false)
-                } else {
-                    throw e
-                }
-            }
+            this.overrideConfig(subId, null)
         } finally {
             Log.i(TAG, "clearConfig done")
-            am.stopDelegateShellPermissionIdentity()
         }
     }
 

--- a/app/src/main/java/dev/bluehouse/enablevolte/BrokerInstrumentation.kt
+++ b/app/src/main/java/dev/bluehouse/enablevolte/BrokerInstrumentation.kt
@@ -26,11 +26,10 @@ class BrokerInstrumentation : Instrumentation() {
             val configurationManager = this.context.getSystemService(CarrierConfigManager::class.java)
 
             try {
-                return configurationManager.overrideConfig(subId, overrideValues, overrideConfigPersistent)
+                configurationManager.overrideConfig(subId, overrideValues, overrideConfigPersistent)
             } catch (e: NoSuchMethodError) {
+                configurationManager.overrideConfig(subId, overrideValues)
             }
-
-            configurationManager.overrideConfig(subId, overrideValues)
         } finally {
             am.stopDelegateShellPermissionIdentity()
         }

--- a/app/src/main/java/dev/bluehouse/enablevolte/Moder.kt
+++ b/app/src/main/java/dev/bluehouse/enablevolte/Moder.kt
@@ -128,7 +128,8 @@ class CarrierModer(
             val sub = this.loadCachedInterface { sub }
             try {
                 return sub.getActiveSubscriptionInfoList(null, null, true) ?: emptyList()
-            } catch (e: NoSuchMethodError) {}
+            } catch (e: NoSuchMethodError) {
+            }
             return try {
                 val getActiveSubscriptionInfoListMethod =
                     sub.javaClass.getMethod(
@@ -398,10 +399,14 @@ class SubscriptionModer(
         return config.get(key)
     }
 
-    fun getConfigForSubId(iCclInstance: ICarrierConfigLoader, subscriptionId: Int): PersistableBundle {
+    fun getConfigForSubId(
+        iCclInstance: ICarrierConfigLoader,
+        subscriptionId: Int,
+    ): PersistableBundle {
         try {
             return iCclInstance.getConfigForSubIdWithFeature(subscriptionId, iCclInstance.defaultCarrierServicePackageName, "")
-        } catch (e: NoSuchMethodError) {}
+        } catch (e: NoSuchMethodError) {
+        }
         return try {
             iCclInstance.getConfigForSubId(subscriptionId, iCclInstance.defaultCarrierServicePackageName)
         } catch (e: NoSuchMethodError) {

--- a/app/src/main/java/dev/bluehouse/enablevolte/Moder.kt
+++ b/app/src/main/java/dev/bluehouse/enablevolte/Moder.kt
@@ -99,7 +99,7 @@ class CarrierModer(
         get() {
             val sub = this.loadCachedInterface { sub }
             try {
-                return sub.getActiveSubscriptionInfoList(null, null, true)
+                return sub.getActiveSubscriptionInfoList(null, null, true) ?: emptyList()
             } catch (e: NoSuchMethodError) {}
             return try {
                 val getActiveSubscriptionInfoListMethod =
@@ -108,14 +108,14 @@ class CarrierModer(
                         String::class.java,
                         String::class.java,
                     )
-                (getActiveSubscriptionInfoListMethod.invoke(sub, null, null) as List<SubscriptionInfo>)
+                (getActiveSubscriptionInfoListMethod.invoke(sub, null, null) as? List<SubscriptionInfo>) ?: emptyList()
             } catch (e: NoSuchMethodException) {
                 val getActiveSubscriptionInfoListMethod =
                     sub.javaClass.getMethod(
                         "getActiveSubscriptionInfoList",
                         String::class.java,
                     )
-                (getActiveSubscriptionInfoListMethod.invoke(sub, null) as List<SubscriptionInfo>)
+                (getActiveSubscriptionInfoListMethod.invoke(sub, null) as? List<SubscriptionInfo>) ?: emptyList()
             }
         }
 

--- a/app/src/main/java/dev/bluehouse/enablevolte/Moder.kt
+++ b/app/src/main/java/dev/bluehouse/enablevolte/Moder.kt
@@ -98,18 +98,24 @@ class CarrierModer(
     val subscriptions: List<SubscriptionInfo>
         get() {
             val sub = this.loadCachedInterface { sub }
+            try {
+                return sub.getActiveSubscriptionInfoList(null, null, true)
+            } catch (e: NoSuchMethodError) {}
             return try {
-                sub.getActiveSubscriptionInfoList(null, null, true)
-            } catch (e: NoSuchMethodError) {
-                // FIXME: lift up reflect as soon as official source code releases
                 val getActiveSubscriptionInfoListMethod =
                     sub.javaClass.getMethod(
                         "getActiveSubscriptionInfoList",
                         String::class.java,
                         String::class.java,
-                        Boolean::class.java,
                     )
-                (getActiveSubscriptionInfoListMethod.invoke(sub, null, null, false) as List<SubscriptionInfo>)
+                (getActiveSubscriptionInfoListMethod.invoke(sub, null, null) as List<SubscriptionInfo>)
+            } catch (e: NoSuchMethodException) {
+                val getActiveSubscriptionInfoListMethod =
+                    sub.javaClass.getMethod(
+                        "getActiveSubscriptionInfoList",
+                        String::class.java,
+                    )
+                (getActiveSubscriptionInfoListMethod.invoke(sub, null) as List<SubscriptionInfo>)
             }
         }
 

--- a/app/src/main/java/dev/bluehouse/enablevolte/Moder.kt
+++ b/app/src/main/java/dev/bluehouse/enablevolte/Moder.kt
@@ -460,7 +460,7 @@ class SubscriptionModer(
     val wfcSpnFormatIndex: Int
         get() = this.getIntValue(CarrierConfigManager.KEY_WFC_SPN_FORMAT_IDX_INT)
 
-    val carrierName: String
+    val carrierName: String?
         get() = this.loadCachedInterface { telephony }.getSubscriptionCarrierName(this.subscriptionId)
 
     val showVoWifiIcon: Boolean

--- a/app/src/main/java/dev/bluehouse/enablevolte/Moder.kt
+++ b/app/src/main/java/dev/bluehouse/enablevolte/Moder.kt
@@ -9,11 +9,15 @@ import android.os.Build
 import android.os.Build.VERSION_CODES
 import android.os.Bundle
 import android.os.IInterface
+import android.os.PersistableBundle
 import android.telephony.CarrierConfigManager
 import android.telephony.SubscriptionInfo
 import android.telephony.TelephonyFrameworkInitializer
 import android.util.Log
 import androidx.annotation.RequiresApi
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import com.android.internal.telephony.ICarrierConfigLoader
 import com.android.internal.telephony.IPhoneSubInfo
 import com.android.internal.telephony.ISub
@@ -26,6 +30,8 @@ import java.time.format.DateTimeParseException
 object InterfaceCache {
     val cache = HashMap<String, IInterface>()
 }
+
+var overrideConfigPersistent by mutableStateOf(true)
 
 open class Moder {
     @Suppress("ktlint:standard:property-naming")
@@ -140,20 +146,11 @@ class SubscriptionModer(
         var noSuchMethodError: NoSuchMethodError? = null
 
         try {
-            return iCclInstance.overrideConfig(subscriptionId, args, true)
+            return iCclInstance.overrideConfig(subscriptionId, args, overrideConfigPersistent)
         } catch (e: SecurityException) {
             securityException = e
         } catch (e: NoSuchMethodError) {
             noSuchMethodError = e
-        }
-
-        try {
-            iCclInstance.overrideConfig(subscriptionId, args, false)
-            throw securityException ?: noSuchMethodError!!
-        } catch (e: SecurityException) {
-            securityException = securityException ?: e
-        } catch (e: NoSuchMethodError) {
-            noSuchMethodError = noSuchMethodError ?: e
         }
 
         val overrideConfigMethod =

--- a/app/src/main/java/dev/bluehouse/enablevolte/Moder.kt
+++ b/app/src/main/java/dev/bluehouse/enablevolte/Moder.kt
@@ -9,6 +9,7 @@ import android.os.Build
 import android.os.Build.VERSION_CODES
 import android.os.Bundle
 import android.os.IInterface
+import android.os.PersistableBundle
 import android.os.ServiceManager
 import android.telephony.CarrierConfigManager
 import android.telephony.SubscriptionInfo
@@ -309,7 +310,7 @@ class SubscriptionModer(
         }
         val iCclInstance = this.loadCachedInterface { carrierConfigLoader }
 
-        val config = iCclInstance.getConfigForSubIdWithFeature(subscriptionId, iCclInstance.defaultCarrierServicePackageName, "")
+        val config = this.getConfigForSubId(iCclInstance, subscriptionId)
         return config.getString(key)
     }
 
@@ -321,7 +322,7 @@ class SubscriptionModer(
         }
         val iCclInstance = this.loadCachedInterface { carrierConfigLoader }
 
-        val config = iCclInstance.getConfigForSubIdWithFeature(subscriptionId, iCclInstance.defaultCarrierServicePackageName, "")
+        val config = this.getConfigForSubId(iCclInstance, subscriptionId)
         return config.getBoolean(key)
     }
 
@@ -333,7 +334,7 @@ class SubscriptionModer(
         }
         val iCclInstance = this.loadCachedInterface { carrierConfigLoader }
 
-        val config = iCclInstance.getConfigForSubIdWithFeature(subscriptionId, iCclInstance.defaultCarrierServicePackageName, "")
+        val config = this.getConfigForSubId(iCclInstance, subscriptionId)
         return config.getInt(key)
     }
 
@@ -345,7 +346,7 @@ class SubscriptionModer(
         }
         val iCclInstance = this.loadCachedInterface { carrierConfigLoader }
 
-        val config = iCclInstance.getConfigForSubIdWithFeature(subscriptionId, iCclInstance.defaultCarrierServicePackageName, "")
+        val config = this.getConfigForSubId(iCclInstance, subscriptionId)
         return config.getLong(key)
     }
 
@@ -357,7 +358,7 @@ class SubscriptionModer(
         }
         val iCclInstance = this.loadCachedInterface { carrierConfigLoader }
 
-        val config = iCclInstance.getConfigForSubIdWithFeature(subscriptionId, iCclInstance.defaultCarrierServicePackageName, "")
+        val config = this.getConfigForSubId(iCclInstance, subscriptionId)
         return config.getBooleanArray(key) ?: BooleanArray(0)
     }
 
@@ -369,7 +370,7 @@ class SubscriptionModer(
         }
         val iCclInstance = this.loadCachedInterface { carrierConfigLoader }
 
-        val config = iCclInstance.getConfigForSubIdWithFeature(subscriptionId, iCclInstance.defaultCarrierServicePackageName, "")
+        val config = this.getConfigForSubId(iCclInstance, subscriptionId)
         return config.getIntArray(key) ?: IntArray(0)
     }
 
@@ -381,7 +382,7 @@ class SubscriptionModer(
         }
         val iCclInstance = this.loadCachedInterface { carrierConfigLoader }
 
-        val config = iCclInstance.getConfigForSubIdWithFeature(subscriptionId, iCclInstance.defaultCarrierServicePackageName, "")
+        val config = this.getConfigForSubId(iCclInstance, subscriptionId)
         return config.getStringArray(key) ?: emptyArray()
     }
 
@@ -393,8 +394,24 @@ class SubscriptionModer(
         }
         val iCclInstance = this.loadCachedInterface { carrierConfigLoader }
 
-        val config = iCclInstance.getConfigForSubIdWithFeature(subscriptionId, iCclInstance.defaultCarrierServicePackageName, "")
+        val config = this.getConfigForSubId(iCclInstance, subscriptionId)
         return config.get(key)
+    }
+
+    fun getConfigForSubId(iCclInstance: ICarrierConfigLoader, subscriptionId: Int): PersistableBundle {
+        try {
+            return iCclInstance.getConfigForSubIdWithFeature(subscriptionId, iCclInstance.defaultCarrierServicePackageName, "")
+        } catch (e: NoSuchMethodError) {}
+        return try {
+            iCclInstance.getConfigForSubId(subscriptionId, iCclInstance.defaultCarrierServicePackageName)
+        } catch (e: NoSuchMethodError) {
+            val getConfigForSubIdMethod =
+                iCclInstance.javaClass.getMethod(
+                    "getConfigForSubId",
+                    Int::class.javaPrimitiveType,
+                )
+            (getConfigForSubIdMethod.invoke(iCclInstance, subscriptionId) as PersistableBundle)
+        }
     }
 
     val simSlotIndex: Int

--- a/app/src/main/java/dev/bluehouse/enablevolte/Moder.kt
+++ b/app/src/main/java/dev/bluehouse/enablevolte/Moder.kt
@@ -287,7 +287,13 @@ class SubscriptionModer(
     fun restartIMSRegistration() {
         val telephony = this.loadCachedInterface { telephony }
         val sub = this.loadCachedInterface { sub }
-        telephony.resetIms(sub.getSlotIndex(this.subscriptionId))
+        try {
+            telephony.resetIms(sub.getSlotIndex(this.subscriptionId))
+        } catch (e: NoSuchMethodError) {
+            telephony.disableIms(sub.getSlotIndex(this.subscriptionId))
+            telephony.enableIms(sub.getSlotIndex(this.subscriptionId))
+            throw e
+        }
     }
 
     fun getStringValue(key: String): String? {

--- a/app/src/main/java/dev/bluehouse/enablevolte/Moder.kt
+++ b/app/src/main/java/dev/bluehouse/enablevolte/Moder.kt
@@ -109,7 +109,17 @@ class CarrierModer(
 ) : Moder() {
     fun getActiveSubscriptionInfoForSimSlotIndex(index: Int): SubscriptionInfo? {
         val sub = this.loadCachedInterface { sub }
-        return sub.getActiveSubscriptionInfoForSimSlotIndex(index, null, null)
+        return try {
+            sub.getActiveSubscriptionInfoForSimSlotIndex(index, null, null)
+        } catch (e: NoSuchMethodError) {
+            val getActiveSubscriptionInfoForSimSlotIndexMethod =
+                sub.javaClass.getMethod(
+                    "getActiveSubscriptionInfoForSimSlotIndex",
+                    Int::class.javaPrimitiveType,
+                    String::class.java,
+                )
+            (getActiveSubscriptionInfoForSimSlotIndexMethod.invoke(sub, index, null) as? SubscriptionInfo)
+        }
     }
 
     val subscriptions: List<SubscriptionInfo>

--- a/app/src/main/java/dev/bluehouse/enablevolte/Moder.kt
+++ b/app/src/main/java/dev/bluehouse/enablevolte/Moder.kt
@@ -312,7 +312,7 @@ class SubscriptionModer(
         val iCclInstance = this.loadCachedInterface { carrierConfigLoader }
 
         val config = this.getConfigForSubId(iCclInstance, subscriptionId)
-        return config.getString(key)
+        return config?.getString(key)
     }
 
     fun getBooleanValue(key: String): Boolean {
@@ -324,7 +324,7 @@ class SubscriptionModer(
         val iCclInstance = this.loadCachedInterface { carrierConfigLoader }
 
         val config = this.getConfigForSubId(iCclInstance, subscriptionId)
-        return config.getBoolean(key)
+        return config?.getBoolean(key) ?: false
     }
 
     fun getIntValue(key: String): Int {
@@ -336,7 +336,7 @@ class SubscriptionModer(
         val iCclInstance = this.loadCachedInterface { carrierConfigLoader }
 
         val config = this.getConfigForSubId(iCclInstance, subscriptionId)
-        return config.getInt(key)
+        return config?.getInt(key) ?: -1
     }
 
     fun getLongValue(key: String): Long {
@@ -348,7 +348,7 @@ class SubscriptionModer(
         val iCclInstance = this.loadCachedInterface { carrierConfigLoader }
 
         val config = this.getConfigForSubId(iCclInstance, subscriptionId)
-        return config.getLong(key)
+        return config?.getLong(key) ?: -1L
     }
 
     fun getBooleanArrayValue(key: String): BooleanArray {
@@ -360,7 +360,7 @@ class SubscriptionModer(
         val iCclInstance = this.loadCachedInterface { carrierConfigLoader }
 
         val config = this.getConfigForSubId(iCclInstance, subscriptionId)
-        return config.getBooleanArray(key) ?: BooleanArray(0)
+        return config?.getBooleanArray(key) ?: BooleanArray(0)
     }
 
     fun getIntArrayValue(key: String): IntArray {
@@ -372,7 +372,7 @@ class SubscriptionModer(
         val iCclInstance = this.loadCachedInterface { carrierConfigLoader }
 
         val config = this.getConfigForSubId(iCclInstance, subscriptionId)
-        return config.getIntArray(key) ?: IntArray(0)
+        return config?.getIntArray(key) ?: IntArray(0)
     }
 
     fun getStringArrayValue(key: String): Array<String> {
@@ -384,7 +384,7 @@ class SubscriptionModer(
         val iCclInstance = this.loadCachedInterface { carrierConfigLoader }
 
         val config = this.getConfigForSubId(iCclInstance, subscriptionId)
-        return config.getStringArray(key) ?: emptyArray()
+        return config?.getStringArray(key) ?: emptyArray()
     }
 
     fun getValue(key: String): Any? {
@@ -396,13 +396,13 @@ class SubscriptionModer(
         val iCclInstance = this.loadCachedInterface { carrierConfigLoader }
 
         val config = this.getConfigForSubId(iCclInstance, subscriptionId)
-        return config.get(key)
+        return config?.get(key)
     }
 
     fun getConfigForSubId(
         iCclInstance: ICarrierConfigLoader,
         subscriptionId: Int,
-    ): PersistableBundle {
+    ): PersistableBundle? {
         try {
             return iCclInstance.getConfigForSubIdWithFeature(subscriptionId, iCclInstance.defaultCarrierServicePackageName, "")
         } catch (e: NoSuchMethodError) {
@@ -415,7 +415,7 @@ class SubscriptionModer(
                     "getConfigForSubId",
                     Int::class.javaPrimitiveType,
                 )
-            (getConfigForSubIdMethod.invoke(iCclInstance, subscriptionId) as PersistableBundle)
+            (getConfigForSubIdMethod.invoke(iCclInstance, subscriptionId) as? PersistableBundle)
         }
     }
 

--- a/app/src/main/java/dev/bluehouse/enablevolte/Moder.kt
+++ b/app/src/main/java/dev/bluehouse/enablevolte/Moder.kt
@@ -9,6 +9,7 @@ import android.os.Build
 import android.os.Build.VERSION_CODES
 import android.os.Bundle
 import android.os.IInterface
+import android.os.ServiceManager
 import android.telephony.CarrierConfigManager
 import android.telephony.SubscriptionInfo
 import android.telephony.TelephonyFrameworkInitializer
@@ -46,10 +47,14 @@ open class Moder {
         get() =
             ICarrierConfigLoader.Stub.asInterface(
                 ShizukuBinderWrapper(
-                    TelephonyFrameworkInitializer
-                        .getTelephonyServiceManager()
-                        .carrierConfigServiceRegisterer
-                        .get()!!,
+                    try {
+                        TelephonyFrameworkInitializer
+                            .getTelephonyServiceManager()
+                            .carrierConfigServiceRegisterer
+                            .get()
+                    } catch (e: NoClassDefFoundError) {
+                        ServiceManager.getService(Context.CARRIER_CONFIG_SERVICE)
+                    }!!,
                 ),
             )
 
@@ -57,10 +62,14 @@ open class Moder {
         get() =
             ITelephony.Stub.asInterface(
                 ShizukuBinderWrapper(
-                    TelephonyFrameworkInitializer
-                        .getTelephonyServiceManager()
-                        .telephonyServiceRegisterer
-                        .get()!!,
+                    try {
+                        TelephonyFrameworkInitializer
+                            .getTelephonyServiceManager()
+                            .telephonyServiceRegisterer
+                            .get()
+                    } catch (e: NoClassDefFoundError) {
+                        ServiceManager.getService(Context.TELEPHONY_SERVICE)
+                    }!!,
                 ),
             )
 
@@ -68,10 +77,14 @@ open class Moder {
         get() =
             IPhoneSubInfo.Stub.asInterface(
                 ShizukuBinderWrapper(
-                    TelephonyFrameworkInitializer
-                        .getTelephonyServiceManager()
-                        .phoneSubServiceRegisterer
-                        .get()!!,
+                    try {
+                        TelephonyFrameworkInitializer
+                            .getTelephonyServiceManager()
+                            .phoneSubServiceRegisterer
+                            .get()
+                    } catch (e: NoClassDefFoundError) {
+                        ServiceManager.getService("iphonesubinfo")
+                    }!!,
                 ),
             )
 
@@ -79,10 +92,14 @@ open class Moder {
         get() =
             ISub.Stub.asInterface(
                 ShizukuBinderWrapper(
-                    TelephonyFrameworkInitializer
-                        .getTelephonyServiceManager()
-                        .subscriptionServiceRegisterer
-                        .get()!!,
+                    try {
+                        TelephonyFrameworkInitializer
+                            .getTelephonyServiceManager()
+                            .subscriptionServiceRegisterer
+                            .get()
+                    } catch (e: NoClassDefFoundError) {
+                        ServiceManager.getService("isub")
+                    }!!,
                 ),
             )
 }

--- a/app/src/main/java/dev/bluehouse/enablevolte/Moder.kt
+++ b/app/src/main/java/dev/bluehouse/enablevolte/Moder.kt
@@ -195,17 +195,19 @@ class SubscriptionModer(
     }
 
     private fun overrideConfig(bundle: Bundle?) {
-        val securityPatchDate = try {
-            LocalDate.parse(Build.VERSION.SECURITY_PATCH)
-        } catch (e: DateTimeParseException) {
-            null
-        }
+        val securityPatchDate =
+            try {
+                LocalDate.parse(Build.VERSION.SECURITY_PATCH)
+            } catch (e: DateTimeParseException) {
+                null
+            }
         if (securityPatchDate == null || securityPatchDate.isBefore(LocalDate.of(2025, 10, 1))) {
             try {
                 return this.overrideConfigDirectly(bundle)
             } catch (e: SecurityException) {
             } catch (e: NoSuchMethodError) {
-            } catch (e: NoSuchMethodException) {}
+            } catch (e: NoSuchMethodException) {
+            }
         }
         this.overrideConfigUsingBroker(bundle)
     }

--- a/app/src/main/java/dev/bluehouse/enablevolte/pages/Config.kt
+++ b/app/src/main/java/dev/bluehouse/enablevolte/pages/Config.kt
@@ -35,6 +35,7 @@ import dev.bluehouse.enablevolte.components.HeaderText
 import dev.bluehouse.enablevolte.components.InfiniteLoadingDialog
 import dev.bluehouse.enablevolte.components.RadioSelectPropertyView
 import dev.bluehouse.enablevolte.components.UserAgentPropertyView
+import dev.bluehouse.enablevolte.overrideConfigPersistent
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -147,6 +148,10 @@ fun Config(
         InfiniteLoadingDialog()
     } else {
         Column(modifier = Modifier.padding(Dp(16f)).verticalScroll(scrollState)) {
+            BooleanPropertyView(label = stringResource(R.string.override_config_persistent), toggled = overrideConfigPersistent) {
+                overrideConfigPersistent = !overrideConfigPersistent
+            }
+
             HeaderText(text = stringResource(R.string.feature_toggles))
             BooleanPropertyView(label = stringResource(R.string.enable_volte), toggled = voLTEEnabled) {
                 voLTEEnabled =

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -80,4 +80,5 @@
   <string name="add_toggle_tile">VoLTE 設定の切り替えタイルを追加する</string>
   <string name="sim_config">SIM の設定</string>
   <string name="config_dump_viewer">設定ダンプビューワー</string>
+  <string name="override_config_persistent">再起動後も変更を保持する (クラッシュ時はオフに)</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -80,4 +80,5 @@
     <string name="add_toggle_tile">添加 VoLTE 开关图块</string>
     <string name="sim_config">SIM 配置</string>
     <string name="config_dump_viewer">配置转储查看器</string>
+    <string name="override_config_persistent">重启后保留修改 (崩溃时请关闭)</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -79,4 +79,5 @@
     <string name="add_toggle_tile">Add VoLTE config toggle tile</string>
     <string name="sim_config">SIM Config</string>
     <string name="config_dump_viewer">Config Dump Viewer</string>
+    <string name="override_config_persistent">Persist Changes across Reboot (Turn Off on Crash)</string>
 </resources>


### PR DESCRIPTION
![Screenshot_20251228-125252_Pixel IMS.jpg](https://github.com/user-attachments/assets/a868f3cf-0c33-4b48-92f8-9e8f459a5c13)

Fixes https://github.com/kyujin-cho/pixel-volte-patch/issues/438#issuecomment-3694049462, closes https://github.com/kyujin-cho/pixel-volte-patch/issues/398#issuecomment-3446763394, resolves #403, by adding a new button to let users try `ICarrierConfigLoader.overrideConfig` or `CarrierConfigManager.overrideConfig` with `persistent=false` since the `SecurityException` which results from`persistent=true` and makes the app crash is not thrown nor caught inside the app but from `com.android.phone`.

Support the different function signatures of [ICarrierConfigLoader.overrideConfig](https://android.googlesource.com/platform/frameworks/base/+/android10-release/telephony/java/com/android/internal/telephony/ICarrierConfigLoader.aidl#29) and [CarrierConfigManager.overrideConfig](https://android.googlesource.com/platform/frameworks/base/+/refs/heads/android10-release/telephony/java/android/telephony/CarrierConfigManager.java#3465) for SDK 29 in case of `NoSuchMethodError`.

Supports `resetIms` for SDK 29 where it was not added but following its implementation by `disableIms` and `enableIms` until [SDK 33](https://android.googlesource.com/platform/packages/services/Telephony/+/android13-release/src/com/android/phone/PhoneInterfaceManager.java#5692), catching `NoSuchMethodError`.

You can download and test the built apk here but need to uninstall the previous release if any: https://github.com/yhkee0404/pixel-volte-patch/releases/tag/1.3.1_PR_426_430_431_432_436