### PR TITLE
refactor: deprecate redundant non-null on user agent

### DIFF
--- a/app/src/main/java/dev/bluehouse/enablevolte/Moder.kt
+++ b/app/src/main/java/dev/bluehouse/enablevolte/Moder.kt
@@ -466,8 +466,8 @@ class SubscriptionModer(
                 false
             }
 
-    val userAgentConfig: String
-        get() = this.getStringValue(KEY_IMS_USER_AGENT) ?: ""
+    val userAgentConfig: String?
+        get() = this.getStringValue(KEY_IMS_USER_AGENT)
 
     val isIMSRegistered: Boolean
         get() {

--- a/app/src/main/java/dev/bluehouse/enablevolte/pages/Config.kt
+++ b/app/src/main/java/dev/bluehouse/enablevolte/pages/Config.kt
@@ -111,12 +111,7 @@ fun Config(
         show4GForLteEnabled = VERSION.SDK_INT >= VERSION_CODES.R && moder.isShow4GForLteEnabled
         hideEnhancedDataIconEnabled = VERSION.SDK_INT >= VERSION_CODES.R && moder.isHideEnhancedDataIconEnabled
         is4GPlusEnabled = moder.is4GPlusEnabled
-        configuredUserAgent =
-            try {
-                moder.userAgentConfig
-            } catch (e: java.lang.NullPointerException) {
-                null
-            }
+        configuredUserAgent = moder.userAgentConfig
     }
 
     LaunchedEffect(true) {


### PR DESCRIPTION
Extends #73 that fixes #70 where `getStringValue` would have thrown `NullPointerException` because its return type `String` did not allow `null` which `config.getString(key)` could indeed return.

https://github.com/kyujin-cho/pixel-volte-patch/blob/45758598b2d6253fbda2525139e6791890ddeb35/app/src/main/java/dev/bluehouse/enablevolte/Moder.kt#L141-L150

https://github.com/kyujin-cho/pixel-volte-patch/blob/45758598b2d6253fbda2525139e6791890ddeb35/app/src/main/java/dev/bluehouse/enablevolte/Moder.kt#L222-L223

https://github.com/kyujin-cho/pixel-volte-patch/blob/45758598b2d6253fbda2525139e6791890ddeb35/app/src/main/java/dev/bluehouse/enablevolte/pages/Config.kt#L60

https://github.com/kyujin-cho/pixel-volte-patch/blob/45758598b2d6253fbda2525139e6791890ddeb35/app/src/main/java/dev/bluehouse/enablevolte/pages/Config.kt#L47

That is why this null check has been added since #73:

https://github.com/kyujin-cho/pixel-volte-patch/blob/622def394bc14927123fe3fff210d60a2a656750/app/src/main/java/dev/bluehouse/enablevolte/pages/Config.kt#L60-L64

https://github.com/kyujin-cho/pixel-volte-patch/blob/622def394bc14927123fe3fff210d60a2a656750/app/src/main/java/dev/bluehouse/enablevolte/pages/Config.kt#L47

However, it has become deprecated since #387 because `getStringValue` has started to prevent the exception by returning `String?` instead of just `String` with its null return being typecast into an empty string.

https://github.com/kyujin-cho/pixel-volte-patch/blob/240d0b2052a7d1ae71f78be5315afcf8f6b3fde5/app/src/main/java/dev/bluehouse/enablevolte/Moder.kt#L271

https://github.com/kyujin-cho/pixel-volte-patch/blob/240d0b2052a7d1ae71f78be5315afcf8f6b3fde5/app/src/main/java/dev/bluehouse/enablevolte/Moder.kt#L456-L457

In fact, we do not even need the typecast as well if we also make `userAgentConfig` nullable as it has been allowed since #73.

https://github.com/kyujin-cho/pixel-volte-patch/blob/240d0b2052a7d1ae71f78be5315afcf8f6b3fde5/app/src/main/java/dev/bluehouse/enablevolte/pages/Config.kt#L77

You can download and test the built apk here but need to uninstall the previous release if any: https://github.com/yhkee0404/pixel-volte-patch/releases/tag/1.3.1_PR_426_430_431_432